### PR TITLE
Address Issue 114 to not use 'secret'

### DIFF
--- a/standard/abstract_tests/TTL/ogcClassA.ttl
+++ b/standard/abstract_tests/TTL/ogcClassA.ttl
@@ -3,7 +3,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix this: <http://secret.binary-array-ld.net/identity.nc/> .
+@prefix this: <http://example.org/identity.nc/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/standard/abstract_tests/TTL/ogcClassB.ttl
+++ b/standard/abstract_tests/TTL/ogcClassB.ttl
@@ -3,7 +3,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix this: <http://secret.binary-array-ld.net/prefix.nc/> .
+@prefix this: <http://example.org/prefix.nc/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/standard/abstract_tests/TTL/ogcClassC.ttl
+++ b/standard/abstract_tests/TTL/ogcClassC.ttl
@@ -4,7 +4,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix this: <http://secret.binary-array-ld.net/alias.nc/> .
+@prefix this: <http://example.org/alias.nc/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/standard/abstract_tests/TTL/ogcClassD.ttl
+++ b/standard/abstract_tests/TTL/ogcClassD.ttl
@@ -4,7 +4,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix this: <http://secret.binary-array-ld.net/attributes.nc/> .
+@prefix this: <http://example.org/attributes.nc/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/standard/abstract_tests/TTL/ogcClassEF.ttl
+++ b/standard/abstract_tests/TTL/ogcClassEF.ttl
@@ -3,7 +3,7 @@
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix this: <http://secret.binary-array-ld.net/reference.nc/> .
+@prefix this: <http://example.org/reference.nc/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/standard/annex-a.adoc
+++ b/standard/annex-a.adoc
@@ -19,7 +19,7 @@ Conformance class for Universal Resource Identifiers definition and interpretati
 
 Identity:
 ----
-http://secret.binary-array-ld.net/identity.nc
+http://example.org/identity.nc
 ----
 
 Input NetCDF File - Defined in CDL:
@@ -52,7 +52,7 @@ include::abstract_tests/TTL/ogcClassA.ttl[]
 
 Identity:
 ----
-http://secret.binary-array-ld.net/prefix.nc
+http://example.org/prefix.nc
 ----
 
 Input NetCDF File - Defined in CDL:
@@ -84,7 +84,7 @@ include::abstract_tests/TTL/ogcClassB.ttl[]
 
 Identity:
 ----
-http://secret.binary-array-ld.net/alias.nc
+http://example.org/alias.nc
 ----
 
 Alias Graph
@@ -124,7 +124,7 @@ include::abstract_tests/TTL/ogcClassC.ttl[]
 
 Identity:
 ----
-http://secret.binary-array-ld.net/attributes.nc
+http://example.org/attributes.nc
 ----
 
 Alias Graph
@@ -165,7 +165,7 @@ include::abstract_tests/TTL/ogcClassD.ttl[]
 
 Identity:
 ----
-http://secret.binary-array-ld.net/reference.nc
+http://example.org/reference.nc
 ----
 
 


### PR DESCRIPTION
This PR addresses #114 to use example.org instead of 'secret*' in the URIs in the test suite and spec doc.